### PR TITLE
Fix Vehicles Build

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -32,9 +32,6 @@ jobs:
     - name: Install tools
       run: make install-tools
 
-    - name: Generate proto code
-      run: make protoc
-
     - name: Lint
       run: make lint
 


### PR DESCRIPTION
Erro de copy-paste, referenciava um passo que ainda não é usado e por isso precisa ser removido.
